### PR TITLE
Disable private tenant, set preferred tenant to global

### DIFF
--- a/base/default_configs/kibana/kibana.yml
+++ b/base/default_configs/kibana/kibana.yml
@@ -19,7 +19,8 @@ elasticsearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
 elasticsearch.ssl.verificationMode: none
 
 opendistro_security.multitenancy.enabled: true
-opendistro_security.multitenancy.tenants.preferred: ["Private", "Global"]
+opendistro_security.multitenancy.tenants.enable_private: false
+opendistro_security.multitenancy.tenants.preferred: ["Global"]
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
 
 # Use this setting if you are running kibana without https


### PR DESCRIPTION
Removes private tenant from preferred tenants and disables the private tenant.
Unfortunately this does not prevent the select tenant UI from popping up.

![image](https://user-images.githubusercontent.com/80279677/122622621-1dbec480-d04e-11eb-8631-c126fbee0992.png)
